### PR TITLE
Encode atom and tuples

### DIFF
--- a/test/poison/atoms_and_tuples.exs
+++ b/test/poison/atoms_and_tuples.exs
@@ -1,0 +1,28 @@
+defmodule Poison.DecoderTest do
+  use ExUnit.Case, async: true
+  @atom :poison
+  @empty_tuple {}
+  @tuple {:poison, {1, :other}}
+
+  test "Encode atoms" do
+    assert @atom ==
+      @atom
+      |> Poison.encode!(encode_atoms: true)
+      |> Poison.decode!()
+  end
+
+  test "Encode tuples" do
+    assert @empty_tuple ==
+      @empty_tuple
+      |> Poison.encode!(encode_tuples: true)
+      |> Poison.decode!()
+  end
+
+  test "Encode tuples with atom values" do
+    assert @tuple ==
+      @tuple
+      |> Poison.encode!(encode_tuples: true, encode_atoms: true)
+      |> Poison.decode!()
+
+  end
+ end


### PR DESCRIPTION
These changes allow Poison to (optionally) encode and decode Elixir atoms and tuples.
They are converted to JSON objects with a `__poison__type__`tag indicating its type.